### PR TITLE
reciever and subject will show twice bug fix

### DIFF
--- a/mail.php
+++ b/mail.php
@@ -133,8 +133,6 @@
     private function set_default_headers(){
       $this->headers[] = 'MIME-Version: 1.0';
       $this->headers[] = "From: {$this->from}";
-      $this->headers[] = "To: {$this->to}";
-      $this->headers[] = "Subject: {$this->subject}";
       # We'll assume a multi-part message so that we can include an HTML and a text version of the email at the
       # very least. If there are attachments, we'll be doing the same thing.
       $this->headers[] = "Content-type: multipart/mixed; boundary=\"PHP-mixed-{$this->boundary_hash}\"";

--- a/mail.php
+++ b/mail.php
@@ -77,9 +77,10 @@
     * The body can be left blank.
     **/
     public function __construct($to, $from, $subject, $text_content = "", $html_content = ""){
+      date_default_timezone_set('America/Los_Angeles');
       $this->to            = $to;
       $this->from          = $from;
-      $this->subject       = $subject;
+      $this->subject       = $this->convert_utf8($subject);
       $this->text_content  = $text_content;
       $this->html_content  = $html_content;
       $this->body          = "";
@@ -142,6 +143,7 @@
       foreach($this->attachments as $attachment){
         $file_name  = basename($attachment);
 
+        $file_name  = $this->convert_utf8($file_name);
         $this->body .= "--PHP-mixed-{$this->boundary_hash}\n";
         $this->body .= "Content-Type: application/octet-stream; name=\"{$file_name}\"\n";
         $this->body .= "Content-Transfer-Encoding: base64\n";
@@ -155,18 +157,21 @@
 
     private function prepare_text(){
       $this->body .= "--PHP-alt-{$this->boundary_hash}\n";
-      $this->body .= "Content-Type: text/plain; charset=\"iso-8859-1\"\n";
-      $this->body .= "Content-Transfer-Encoding: 7bit\n\n";
+      $this->body .= "Content-Type: text/plain; charset=\"utf-8\"\n";
+      $this->body .= "Content-Transfer-Encoding: 8bit\n\n";
       $this->body .= $this->text_content."\n\n";
     }
 
     private function prepare_html(){
       $this->body .= "--PHP-alt-{$this->boundary_hash}\n";
-      $this->body .= "Content-Type: text/html; charset=\"iso-8859-1\"\n";
-      $this->body .= "Content-Transfer-Encoding: 7bit\n\n";
+      $this->body .= "Content-Type: text/html; charset=\"utf-8\"\n";
+      $this->body .= "Content-Transfer-Encoding: 8bit\n\n";
       $this->body .= $this->html_content."\n\n";
     }
-
+    //convert to  utf8 
+    private function convert_utf8($subject){
+        return '=?UTF-8?B?'.base64_encode($subject).'?=';
+    }
 
   }
 


### PR DESCRIPTION
when i use it in my company's webserver,it give me a warning that timezone not set! The chinese subject will show error code and subject,reciever show twice ! so i change it to support utf-8 and fix bug for it.utf-8 is more useful to people not use english and it support english too! so it's more powerfull!
